### PR TITLE
Fixed #3

### DIFF
--- a/rasa_core_sdk/executor.py
+++ b/rasa_core_sdk/executor.py
@@ -149,7 +149,8 @@ class ActionExecutor(object):
         actions = utils.all_subclasses(Action)
 
         for action in actions:
-            if not action.__module__.startswith("rasa_core."):
+            if not action.__module__.startswith("rasa_core.") and 
+               not action.__module__.startswith("rasa_core_sdk."):
                 self.register_action(action)
 
     @staticmethod


### PR DESCRIPTION
If we have form actions we also get `<class 'rasa_core_sdk.forms.FormAction'>` from `utils.all_subclasses(Action)` in addition to the user defined actions which raises `NotImplementedError` when its `name()` is called. Details are mentioned in #3 .