### PR TITLE
Fix event name for AgentUttered event

### DIFF
--- a/rasa_core_sdk/events.py
+++ b/rasa_core_sdk/events.py
@@ -134,7 +134,7 @@ def ActionExecuted(action_name, timestamp=None):
 # noinspection PyPep8Naming
 def AgentUttered(text=None, data=None, timestamp=None):
     return {
-        "event": "action",
+        "event": "agent",
         "text": text,
         "data": data,
         "timestamp": timestamp,


### PR DESCRIPTION
It looks like the event name for `rasa_core_sdk.events.AgentUttered` does not match the one used in `rasa_core`: https://github.com/RasaHQ/rasa_core/blob/88ca65490db368053aac74eab86735e97ba71da8/rasa_core/events/__init__.py#L749

This makes the SDK use the same string.