### PR TITLE
Validate methods for slots

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ This project adheres to `Semantic Versioning`_ starting with version 0.11.0.
 
 Added
 -----
+- add optional `validate_{slot}` methods to `FormAction`
 
 Removed
 -------

--- a/rasa_core_sdk/forms.py
+++ b/rasa_core_sdk/forms.py
@@ -251,8 +251,14 @@ class FormAction(Action):
         # extract requested slot
         slot_to_fill = tracker.get_slot(REQUESTED_SLOT)
         if slot_to_fill:
-            slot_values.update(self.extract_requested_slot(dispatcher,
-                                                           tracker, domain))
+            for slot, value in self.extract_requested_slot(dispatcher,
+                                                           tracker,
+                                                           domain).items():
+                validate_func = getattr(self, "validate_{}".format(slot),
+                                        lambda *x: value)
+                slot_values[slot] = validate_func(value, dispatcher, tracker,
+                                                  domain)
+
             if not slot_values:
                 # reject to execute the form action
                 # if some slot was requested but nothing was extracted


### PR DESCRIPTION
**Proposed changes**:
-  `validate()` function calls optionally `validate_{slot_name}` functions to validate slot values
- `validate_{slot_name}` returns None for invalid values

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog
