### PR TITLE
added latest_input_channel to tracker

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ This project adheres to `Semantic Versioning`_ starting with version 0.11.0.
 Added
 -----
 - add optional `validate_{slot}` methods to `FormAction`
+- Function to get latest input channel from the tracker with
+  ``tracker.get_latest_input_channel()``
 
 Removed
 -------

--- a/rasa_core_sdk/__init__.py
+++ b/rasa_core_sdk/__init__.py
@@ -76,6 +76,7 @@ class Tracker(object):
             "latest_event_time": latest_event_time,
             "paused": self.is_paused(),
             "events": self.events,
+            "latest_input_channel": self.get_latest_input_channel(),
             "active_form": self.active_form,
             "latest_action_name": self.latest_action_name
         }
@@ -107,6 +108,14 @@ class Tracker(object):
         return (x.get("value")
                 for x in entities
                 if x.get("entity") == entity_type)
+
+    def get_latest_input_channel(self):
+        # type: () -> Optional[Text]
+        """Get the name of the input_channel of the latest UserUttered event"""
+
+        for e in reversed(self.events):
+            if e.get("event") == "user":
+                return e.get("input_channel")
 
     def is_paused(self):
         # type: () -> bool

--- a/rasa_core_sdk/events.py
+++ b/rasa_core_sdk/events.py
@@ -14,12 +14,14 @@ EventType = Dict[Text, Any]
 # noinspection PyPep8Naming
 def UserUttered(text,
                 parse_data=None,
-                timestamp=None):
+                timestamp=None,
+                input_channel=None):
     return {
         "event": "user",
         "timestamp": timestamp,
         "text": text,
         "parse_data": parse_data,
+        "input_channel": input_channel
     }
 
 

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -10,7 +10,9 @@ from rasa_core_sdk.events import ActionExecuted, UserUttered
 def test_latest_input_channel():
     tracker = Tracker('default', {},
                       {'intent': {'name': 'some_intent', 'confidence': 1.0}},
-                      [UserUttered("my message text", input_channel="superchat"),
-                       ActionExecuted("action_listen")], False, None, {}, 'action_listen')
+                      [UserUttered("my message text",
+                                   input_channel="superchat"),
+                       ActionExecuted("action_listen")],
+                      False, None, {}, 'action_listen')
 
     assert tracker.get_latest_input_channel() == "superchat"

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -1,0 +1,16 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from rasa_core_sdk import Tracker
+from rasa_core_sdk.events import ActionExecuted, UserUttered
+
+
+def test_latest_input_channel():
+    tracker = Tracker('default', {},
+                      {'intent': {'name': 'some_intent', 'confidence': 1.0}},
+                      [UserUttered("my message text", input_channel="superchat"),
+                       ActionExecuted("action_listen")], False, None, {}, 'action_listen')
+
+    assert tracker.get_latest_input_channel() == "superchat"

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -10,17 +10,9 @@ from rasa_core_sdk.events import ActionExecuted, UserUttered
 def test_latest_input_channel():
     tracker = Tracker('default', {},
                       {'intent': {'name': 'some_intent', 'confidence': 1.0}},
-<<<<<<< HEAD
                       [UserUttered("my message text",
                                    input_channel="superchat"),
                        ActionExecuted("action_listen")],
                       False, None, {}, 'action_listen')
-=======
-                      [
-                          UserUttered(
-                              "my message text", input_channel="superchat"
-                          ), ActionExecuted("action_listen")
-                      ], False, None, {}, 'action_listen')
->>>>>>> 66f712dcfb614ee4466bf7614538a7bf3bde0c8f
 
     assert tracker.get_latest_input_channel() == "superchat"


### PR DESCRIPTION
I just realized that the `tracker.get_latest_input_channel` feature I've had in my fork for a while is not part of the official `rasa_core_sdk` yet (but is part of `rasa_core`). Because there's been multiple requests about this on the forum (e.g. [here](https://forum.rasa.com/t/how-to-detect-chat-platform-in-actions-py/2991/8) or [here](https://forum.rasa.com/t/action-latest-action-name-followup-action-latest-input-channel-return-none/4157)) I wanted to push this change.

**Proposed changes**:
- Similar to `rasa_core`'s approach, we reverse traverse tracker.events until latest `user` event is found. Then return `event.input_channel` 

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [ ] updated the documentation
- [x] updated the changelog
