### PR TITLE
Allow for early form deactivation during validation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,13 +15,14 @@ Added
 -----
 - add optional `validate_{slot}` methods to `FormAction`
 - forms can now be deactivated during the validation function by returning
-  `self._deactivate()`
+  `self.deactivate()`
 
 Removed
 -------
 
 Changed
 -------
+- `self._deactivate()` renamed to `self.deactivate()`
 
 Fixed
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ This project adheres to `Semantic Versioning`_ starting with version 0.11.0.
 Added
 -----
 - add optional `validate_{slot}` methods to `FormAction`
+- forms can now be deactivated during the validation function by returning
+  `self._deactivate()`
 
 Removed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,7 +22,8 @@ Removed
 
 Changed
 -------
-- `self._deactivate()` renamed to `self.deactivate()`
+- ``self._deactivate()`` method from the ``FormAction`` class has been
+  renamed to ``self.deactivate()``
 
 Fixed
 -----

--- a/rasa_core_sdk/forms.py
+++ b/rasa_core_sdk/forms.py
@@ -391,22 +391,26 @@ class FormAction(Action):
         # validate user input
         events.extend(self._validate_if_required(dispatcher, tracker, domain))
 
-        # create temp tracker with populated slots from `validate` method
-        temp_tracker = tracker.copy()
-        for e in events:
-            if e['event'] == 'slot':
-                temp_tracker.slots[e["name"]] = e["value"]
+        # check that the form wasn't deactivated in validation
+        if Form(None) not in events:
 
-        next_slot_events = self.request_next_slot(dispatcher, temp_tracker,
-                                                  domain)
-        if next_slot_events is not None:
-            # request next slot
-            events.extend(next_slot_events)
-        else:
-            # there is nothing more to request, so we can submit
-            events.extend(self.submit(dispatcher, temp_tracker, domain))
-            # deactivate the form after submission
-            events.extend(self._deactivate())
+            # create temp tracker with populated slots from `validate` method
+            temp_tracker = tracker.copy()
+            for e in events:
+                if e['event'] == 'slot':
+                    temp_tracker.slots[e["name"]] = e["value"]
+
+            next_slot_events = self.request_next_slot(dispatcher, temp_tracker,
+                                                      domain)
+
+            if next_slot_events is not None:
+                # request next slot
+                events.extend(next_slot_events)
+            else:
+                # there is nothing more to request, so we can submit
+                events.extend(self.submit(dispatcher, temp_tracker, domain))
+                # deactivate the form after submission
+                events.extend(self._deactivate())
 
         return events
 

--- a/rasa_core_sdk/forms.py
+++ b/rasa_core_sdk/forms.py
@@ -369,7 +369,7 @@ class FormAction(Action):
 
         return tracker.get_slot(slot_name) is None
 
-    def _deactivate(self):
+    def deactivate(self):
         # type: () -> List[Dict]
         """Return `Form` event with `None` as name to deactivate the form
             and reset the requested slot"""
@@ -410,7 +410,7 @@ class FormAction(Action):
                 # there is nothing more to request, so we can submit
                 events.extend(self.submit(dispatcher, temp_tracker, domain))
                 # deactivate the form after submission
-                events.extend(self._deactivate())
+                events.extend(self.deactivate())
 
         return events
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -485,7 +485,7 @@ def test_early_deactivation():
             return ["some_slot", "some_other_slot"]
 
         def validate(self, dispatcher, tracker, domain):
-            return self._deactivate()
+            return self.deactivate()
 
     form = CustomFormAction()
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -472,3 +472,4 @@ def test_validate_if_required():
     # check that validation was skipped
     # because previous action is not action_listen
     assert events == []
+

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -472,4 +472,3 @@ def test_validate_if_required():
     # check that validation was skipped
     # because previous action is not action_listen
     assert events == []
-

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -472,3 +472,32 @@ def test_validate_if_required():
     # check that validation was skipped
     # because previous action is not action_listen
     assert events == []
+
+
+def test_early_deactivation():
+    # noinspection PyAbstractClass
+    class CustomFormAction(FormAction):
+        def name(self):
+            return "some_form"
+
+        @staticmethod
+        def required_slots(_tracker):
+            return ["some_slot", "some_other_slot"]
+
+        def validate(self, dispatcher, tracker, domain):
+            return self._deactivate()
+
+    form = CustomFormAction()
+
+    tracker = Tracker('default', {'some_slot': 'some_value'},
+                      {'intent': 'greet'},
+                      [], False, None,
+                      {'name': 'some_form',
+                       'validate': True, 'rejected': False},
+                      'action_listen')
+
+    events = form.run(dispatcher=None, tracker=tracker, domain=None)
+
+    # check that form was deactivated before requesting next slot
+    assert events == [Form(None), SlotSet('requested_slot', None)]
+    assert SlotSet('requested_slot', "some_other_slot") not in events


### PR DESCRIPTION
If a slot could not be validated properly, we may want to deactivate the form immediately (e.g. without submitting).  Currently, adding `self._deactivate()` to the events would still cause the rest of the `run()` method to continue.

**Proposed changes**:
- Add a check in the `run()` method that we didn't already try to deactivate
- Rename method to `deativate()` (i.e. remove the "protected" status)

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [x] added some tests for the functionality
- [x] updated the documentation
- [x] updated the changelog
