### PR TITLE
Validate for all extracted slots

### DIFF
--- a/rasa_core_sdk/forms.py
+++ b/rasa_core_sdk/forms.py
@@ -254,21 +254,22 @@ class FormAction(Action):
             slot_values.update(self.extract_requested_slot(dispatcher,
                                                            tracker,
                                                            domain))
-            for slot, value in slot_values.items():
-                validate_func = getattr(self, "validate_{}".format(slot),
-                                        lambda *x: value)
-                slot_values[slot] = validate_func(value, dispatcher, tracker,
-                                                  domain)
 
             if not slot_values:
                 # reject to execute the form action
                 # if some slot was requested but nothing was extracted
                 # it will allow other policies to predict another action
                 raise ActionExecutionRejection(self.name(),
-                                               "Failed to validate slot {0} "
+                                               "Failed to extract slot {0} "
                                                "with action {1}"
                                                "".format(slot_to_fill,
                                                          self.name()))
+
+            for slot, value in slot_values.items():
+                validate_func = getattr(self, "validate_{}".format(slot),
+                                        lambda *x: value)
+                slot_values[slot] = validate_func(value, dispatcher, tracker,
+                                                  domain)
 
         # validation succeed, set slots to extracted values
         return [SlotSet(slot, value) for slot, value in slot_values.items()]

--- a/rasa_core_sdk/forms.py
+++ b/rasa_core_sdk/forms.py
@@ -251,9 +251,10 @@ class FormAction(Action):
         # extract requested slot
         slot_to_fill = tracker.get_slot(REQUESTED_SLOT)
         if slot_to_fill:
-            for slot, value in self.extract_requested_slot(dispatcher,
+            slot_values.update(self.extract_requested_slot(dispatcher,
                                                            tracker,
-                                                           domain).items():
+                                                           domain))
+            for slot, value in slot_values.items():
                 validate_func = getattr(self, "validate_{}".format(slot),
                                         lambda *x: value)
                 slot_values[slot] = validate_func(value, dispatcher, tracker,

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -388,7 +388,7 @@ def test_validate():
 
     # check that validation failed gracefully
     assert execinfo.type == ActionExecutionRejection
-    assert ("Failed to validate slot some_slot "
+    assert ("Failed to extract slot some_slot "
             "with action some_form" in str(execinfo.value))
 
 


### PR DESCRIPTION
**Proposed changes**:
- Modified `validate` function to validate all extracted slots. Previously it validates only requested slot but not extracted other slots.

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] added some tests for the functionality
- [ ] updated the documentation
- [ ] updated the changelog