### PR TITLE
re-add Element and Button classes from rasa.core.dispatcher

### DIFF
--- a/rasa_core_sdk/executor.py
+++ b/rasa_core_sdk/executor.py
@@ -70,7 +70,6 @@ class CollectingDispatcher(object):
 
         self.messages.append(message)
 
-    # TODO: deprecate this function?
     # noinspection PyUnusedLocal
     def utter_button_template(
         self,

--- a/rasa_core_sdk/utils.py
+++ b/rasa_core_sdk/utils.py
@@ -4,10 +4,22 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import inspect
-
-from typing import Any, List
-
 import logging
+
+
+class Element(dict):
+    __acceptable_keys = ["title", "item_url", "image_url", "subtitle", "buttons"]
+
+    def __init__(self, *args, **kwargs):
+        kwargs = {
+            key: value for key, value in kwargs.items() if key in self.__acceptable_keys
+        }
+
+        super(Element, self).__init__(*args, **kwargs)
+
+
+class Button(dict):
+    pass
 
 
 def all_subclasses(cls):


### PR DESCRIPTION
**Proposed changes**:
- move `Element` and `Button` classes to sdk utils so that anyone using these classes in custom actions can still import them
- remove possible deprecation of utter_button_template since it's useful for cases in which the button payloads are written in a custom action (see medicare bot)

**Status (please check what you already did)**:
- [x] made PR ready for code review
- [ ] add import change to migrations in new docs once i figure out where to put the migration
